### PR TITLE
docs: add UTM attribution params to intents.rozo.ai links

### DIFF
--- a/products/intent-based-bridge/intent-based-bridge.md
+++ b/products/intent-based-bridge/intent-based-bridge.md
@@ -21,7 +21,7 @@ versus Traditional bridges require users to perform two separate actions: author
 
 ## **Web UI:**&#x20;
 
-{% embed url="https://intents.rozo.ai/" %}
+{% embed url="https://intents.rozo.ai/?utm_source=docs&utm_medium=referral" %}
 
 **API Integration** : [https://docs.rozo.ai/api-doc](https://docs.rozo.ai/api-doc)
 

--- a/products/intent-based-earn.md
+++ b/products/intent-based-earn.md
@@ -294,7 +294,7 @@ We build infrastructure that lets anyone earn yield and make payments — withou
 **Try ROZO:**
 
 * [ROZO Earn](https://earn.rozo.ai) — Earn yield on USDC&#x20;
-* [ROZO Bridge](https://intents.rozo.ai/bridge) — Intent based bridge
+* [ROZO Bridge](https://intents.rozo.ai/bridge?utm_source=docs&utm_medium=referral) — Intent based bridge
 
 ***
 


### PR DESCRIPTION
Links from docs.rozo.ai to the bridge web UI now carry `utm_source=docs&utm_medium=referral`, so visits and paid conversions originating from the docs can be attributed by channel (the bridge frontend already captures `utm_*` params into PostHog and payment metadata).

- `products/intent-based-earn.md`: ROZO Bridge link
- `products/intent-based-bridge/intent-based-bridge.md`: Web UI embed

🤖 Generated with [Claude Code](https://claude.com/claude-code)